### PR TITLE
bug:Kafka Consume 시, deserializer에서 trusted 패키지가 아니라서 발생하는 에러 해결.

### DIFF
--- a/src/main/java/com/verifymycoin/VerificationManager/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/verifymycoin/VerificationManager/common/config/KafkaConsumerConfig.java
@@ -24,13 +24,16 @@ public class KafkaConsumerConfig {
 
     @Bean
     public ConsumerFactory consumerFactory() {
+        JsonDeserializer<Verification> deserializer = new JsonDeserializer<>(Verification.class);
+        deserializer.addTrustedPackages("*");
+
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);    // ack 수행하기 위해 false
-        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), new JsonDeserializer<>(Verification.class));
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(), deserializer);
     }
 
     @Bean


### PR DESCRIPTION
deserializer에 trustedPackage를 모두(*) 등록함
error msg
Caused by: java.lang.IllegalArgumentException: The class 'com.verifymycoin.UserManager.user.domain.KafkaSignOutMsgDto' is not in the trusted packages: [java.util, java.lang, com.verifymycoin.VerificationManager.model.entity, com.verifymycoin.VerificationManager.model.entity.*]. If you believe this class is safe to deserialize, please provide its name. If the serialization is only done by a trusted source, you can also enable trust all (*).